### PR TITLE
switch to babel-core, move to peerDeps, widen range

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-var Babel = require('babel');
+var Babel = require('babel-core');
 var SourceMap = require('source-map');
 
 var internals = {};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "homepage": "https://github.com/nlf/lab-babel",
   "dependencies": {
-    "babel": "^4.7.12",
     "source-map": "^0.4.2"
+  },
+  "peerDependencies": {
+    "babel-core": ">=4.x.x"
   }
 }


### PR DESCRIPTION
- `babel` is now the CLI and `babel-core` is the consumable library
- moving to `peerDependencies` allows users to use whatever version they want - babel is moving fast
- widen range - I've tried this with babel-core@~4.1, ^4, and latest and all work so I don't think the API has changed.
