### PR TITLE
streamline module with `sourceMap: inline` option and add helper skipping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 var Babel = require('babel-core');
-var SourceMap = require('source-map');
 
 var internals = {};
 internals.transform = function (content, filename) {
@@ -8,33 +7,14 @@ internals.transform = function (content, filename) {
         return content;
     }
 
-    content = '// $start$\n' + content;
-    var transformed = Babel.transform(content, { sourceMap: true, sourceFileName: filename });
-
-    var lines = transformed.code.split('\n');
-    lines.splice(lines.indexOf('"use strict";') + 1, 0, '// $lab:coverage:off$');
-    lines.splice(lines.indexOf('// $start$'), 1, '// $lab:coverage:on$');
-
-    var smc = new SourceMap.SourceMapConsumer(transformed.map);
-    var sm = new SourceMap.SourceMapGenerator();
-    smc.eachMapping(function (map) {
-
-        sm.addMapping({
-            generated: {
-                line: map.generatedLine,
-                column: map.generatedColumn
-            },
-            original: {
-                line: --map.originalLine,
-                column: map.originalColumn
-            },
-            source: map.source,
-            name: map.name
-        });
+    var transformed = Babel.transform(content, {
+        sourceMap: 'inline',
+        sourceFileName: filename,
+        auxiliaryCommentBefore: '$lab:coverage:off$',
+        auxiliaryCommentAfter: '$lab:coverage:on$'
     });
 
-    lines.push('//# sourceMappingURL=data:application/json;base64,' + new Buffer(sm.toString()).toString('base64'));
-    return lines.join('\n');
+    return transformed.code;
 };
 
 internals.extensions = ['js', 'jsx', 'es', 'es6'];

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "url": "https://github.com/nlf/lab-babel/issues"
   },
   "homepage": "https://github.com/nlf/lab-babel",
-  "dependencies": {
-    "source-map": "^0.4.2"
-  },
   "peerDependencies": {
     "babel-core": ">=4.x.x"
   }


### PR DESCRIPTION
I've simplified the logic to this module by enabling inline sourcemaps in the babel transformation.  This feature seems to have been available for much of babel's existence, but I didn't even know about it until digging into their `auxiliaryComment` option to add comment prefixes to their helpers.  I've also added support to skip their helper blocks in lab coverage using before/after auxiliary blocks which were added based on https://github.com/babel/babel/issues/1721 - the options haven't been released yet but will be ignored for older versions so they should be backwards compatible.
