### PR TITLE
update to babel 6

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,10 +8,12 @@ internals.transform = function (content, filename) {
     }
 
     var transformed = Babel.transform(content, {
+        filename: filename,
         sourceMap: 'inline',
         sourceFileName: filename,
         auxiliaryCommentBefore: '$lab:coverage:off$',
-        auxiliaryCommentAfter: '$lab:coverage:on$'
+        auxiliaryCommentAfter: '$lab:coverage:on$',
+        presets: ["es2015"]
     });
 
     return transformed.code;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/nlf/lab-babel",
   "peerDependencies": {
-    "babel-core": ">=4.x.x"
+    "babel-core": ">=6.x.x",
+    "babel-preset-es2015": "^6.x.x"
   }
 }


### PR DESCRIPTION
These changes are necessary to use the plugin with babel 6. 

This will break compatibility with previous versions, since the `presets` options wasn't present before and it's now mandatory:

```
ReferenceError: [BABEL] test/index.js: Unknown option: direct.presets 
```

Do you think you can publish a new version `1.2.0` for `babel>=6` ?
