### PR TITLE
Add instructions for Babel 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ lab-babel is a small transform to allow testing your es6/jsx modules with lab, c
 Any module (that is *not* in `node_modules`) required via your tests with an extension of `.js`, `.jsx`, `.es`, or `.es6` will be transpiled with babel and have sourcemaps inlined so that lab can show appropriate line numbers.
 
 For more information on writing tests in lab, see the [README](https://github.com/hapijs/lab).
+
+### Babel >= 6
+For Babel versions greather than 6, please install [`babel-preset-es2015`](https://www.npmjs.com/package/babel-preset-es2015) add the following to your [`.babelrc`](https://babeljs.io/docs/usage/babelrc/):
+```
+{
+  "presets": ["es2015"]
+}
+```
+(this could be added to the `babel` section of yor `package.json`, as described by the [`.babelrc`](https://babeljs.io/docs/usage/babelrc/#use-via-package-json) documentation)


### PR DESCRIPTION
Add instructions to use the plugin with babel 6, as pointed out in #6 before.
