### PR TITLE
Added dot character to each item of extensions array.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ internals.transform = function (content, filename) {
     return transformed.code;
 };
 
-internals.extensions = ['js', 'jsx', 'es', 'es6'];
+internals.extensions = ['.js', '.jsx', '.es', '.es6'];
 internals.methods = [];
 for (var i = 0, il = internals.extensions.length; i < il; ++i) {
     internals.methods.push({ ext: internals.extensions[i], transform: internals.transform });


### PR DESCRIPTION
It was not transforming `jsx` files causing `Cannot find module` error when importing from `js` file. With dot character in the extensions was possible to transform all modules properly.