### PR TITLE
Support Babel 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Any module (that is *not* in `node_modules`) required via your tests with an ext
 
 For more information on writing tests in lab, see the [README](https://github.com/hapijs/lab).
 
-### Babel >= 6
-For Babel versions greather than 6, please install [`babel-preset-es2015`](https://www.npmjs.com/package/babel-preset-es2015) add the following to your [`.babelrc`](https://babeljs.io/docs/usage/babelrc/):
-```
-{
-  "presets": ["es2015"]
-}
-```
-(this could be added to the `babel` section of yor `package.json`, as described by the [`.babelrc`](https://babeljs.io/docs/usage/babelrc/#use-via-package-json) documentation)
+### Babel
+
+For Babel 6.x, please install [`babel-preset-env`](https://www.npmjs.com/package/babel-preset-env) and modify your [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) or [`package.json`](https://babeljs.io/docs/usage/babelrc/#use-via-package-json) accordingly.
+
+For Babel >= 7, you'll need to install [scoped packages](https://babeljs.io/docs/en/next/v7-migration#scoped-packages) and configure Babel to use them instead.
+
+
+### Global variable leak
 
 Note that `__core-js_shared__` might be detected as a leak, but you can ignore it by
 declaring it as global with `--globals __core-js_shared__` (or `-I __core-js_shared__`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,14 @@
-var Babel = require('babel-core');
+var Babel;
+
+try {
+    Babel = require('@babel/core');
+} catch (ex) {
+    try {
+        Babel = require('babel-core');
+    } catch (ex) {
+        throw new Error('Neither @babel/core nor babel-core package is installed!');
+    }
+}
 
 var internals = {};
 internals.transform = function (content, filename) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/nlf/lab-babel",
   "peerDependencies": {
-    "babel-core": ">=4.x.x"
+    "babel-core": ">=4.x.x",
+    "@babel/core": ">=7.0.0-beta.4"
   }
 }


### PR DESCRIPTION
This PR adds [**@babel/core**](https://www.npmjs.com/package/@babel/core) as a peer dependency and modifies [`lib/index.js`](https://github.com/nlf/lab-babel/compare/master...fardjad:feature/support-babel-7?expand=1#diff-6d186b954a58d5bb740f73d84fe39073R3) so that it tries requiring **@babel/core** first and then falls back to **babel-core**.